### PR TITLE
Remove Promise.finally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- `promise.finally` because it is not supported by all browsers
+
 ## [0.5.0] - 2018-07-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.5.1] - 2018-08-17
+
 ### Fixed
 
 - `promise.finally` because it is not supported by all browsers

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/mocha",
   "description": "Mocha helpers for testing big",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/mocha",
   "main": "dist/umd/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -54,12 +54,15 @@ function convergentHook(hook) {
     // update timeout in case it changed
     ms = timeout(this) || ms;
 
+    // reset the hook timeout later
+    let reset = () => this.timeout(ms);
+
     // return a promise so we can always reset the timeout
     return Promise.resolve()
     // if a convergence was returned, run it with the timeout
       .then(() => isConvergence(results) ? results.timeout(ms) : results)
-    // reset the hook timeout
-      .finally(() => this.timeout(ms));
+    // reset the timeout on success or error (no finally support)
+      .then(reset, err => { reset(); throw err; });
   });
 }
 


### PR DESCRIPTION
## Purpose

While `Promise.finally` is supported in node where our tests run, it is not supported by all major browsers.

## Approach

Replace `finally` with `then(callback, catch)` and call reset in both situations.